### PR TITLE
sets eventlet version to always be 0.14.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
     install_requires = [
         "httplib2",
         "argparse",
-        "eventlet>=0.9.16",
+        "eventlet==0.14.0",
     ],
 )


### PR DESCRIPTION
mantrid crashes with eventlet 0.15.0 with following error:

``` bash
$ mantrid-client list
Traceback (most recent call last):
  File "/usr/local/bin/mantrid-client", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2707, in <module>
    working_set.require(__requires__)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 686, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 584, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: eventlet>=0.9.16
```

Forcing it to use 0.14.0 fixes the issue.
