### PR TITLE
Add support for X-Loadbalance-To header

### DIFF
--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -339,7 +339,7 @@ class Balancer(object):
             headers = mimetools.Message(rfile, 0)
             # Work out the host
             try:
-                host = headers['LoadBalanceTo']
+                host = headers['X-Loadbalance-To'] if 'X-Loadbalance-To' in headers else headers['LoadBalanceTo']
             except KeyError:
                 host = "unknown"
             headers['Connection'] = "close\r"


### PR DESCRIPTION
We can't use LoadBalanceTo header when passing requests from vulcanproxy to mantrid because at some point vulcanproxy changes (decamelize) LoadBalanceTo into Loadbalanceto (don't know why, maybe to be compliant with some RFC specification?). So we need to introduce another form and we chose X-Loadbalance-To.