### PR TITLE
Check whether there are healthy backend available

### DIFF
--- a/examples/default.conf
+++ b/examples/default.conf
@@ -1,7 +1,7 @@
 # This configuration file is equivalent to the default Mantrid configuration.
 
-# Bind to all address on port 80 for untrusted connections
-bind = *:80
+# Bind to all address on port 8080 for untrusted connections
+bind = *:8080
 
 # Don't bind to any addresses for trusted connections
 # bind_internal = [::1]:81

--- a/examples/default.conf
+++ b/examples/default.conf
@@ -1,7 +1,7 @@
 # This configuration file is equivalent to the default Mantrid configuration.
 
-# Bind to all address on port 8080 for untrusted connections
-bind = *:8080
+# Bind to all address on port 80 for untrusted connections
+bind = *:80
 
 # Don't bind to any addresses for trusted connections
 # bind_internal = [::1]:81

--- a/mantrid/actions.py
+++ b/mantrid/actions.py
@@ -161,8 +161,6 @@ class Proxy(Action):
 
     def least_connections(self):
         backends = self.valid_backends()
-        if len(backends) == 0:
-          logging.warn("No healthy backends for host: %s!", self.host)
         
         try:
             min_connections = min(b.connections for b in backends)

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -379,7 +379,7 @@ class Balancer(object):
         except NoHealthyBackends, e:
             logging.error("No healthy bakckends available!")
             try:
-                sock.sendall("HTTP/1.0 503 No Healthy Backends\r\n\r\nNo healthy bakckends available.")
+                sock.sendall("HTTP/1.0 597 No Healthy Backends\r\n\r\nNo healthy bakckends available.")
             except socket.error, e:
                 if e.errno != errno.EPIPE:
                     raise

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -379,7 +379,7 @@ class Balancer(object):
         except NoHealthyBackends, e:
             logging.error("No healthy bakckends available!")
             try:
-                sock.sendall("HTTP/1.0 597 No Healthy Backends\r\n\r\nNo healthy bakckends available.")
+                sock.sendall("HTTP/1.0 503 No Healthy Backends\r\n\r\nNo healthy bakckends available.")
             except socket.error, e:
                 if e.errno != errno.EPIPE:
                     raise

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -377,7 +377,7 @@ class Balancer(object):
             if e.errno not in (errno.EPIPE, errno.ETIMEDOUT, errno.ECONNRESET):
                 logging.error(traceback.format_exc())
         except NoHealthyBackends, e:
-            logging.error("No healthy bakckends available!")
+            logging.error("No healthy bakckends available for host '%s'" % host)
             try:
                 sock.sendall("HTTP/1.0 597 No Healthy Backends\r\n\r\nNo healthy bakckends available.")
             except socket.error, e:

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -13,7 +13,7 @@ from eventlet.green import socket
 
 import mantrid.json
 
-from mantrid.actions import Unknown, Proxy, Empty, Static, Redirect, NoHosts, Spin
+from mantrid.actions import NoHealthyBackends, Unknown, Proxy, Empty, Static, Redirect, NoHosts, Spin
 from mantrid.config import SimpleConfig
 from mantrid.management import ManagementApp
 from mantrid.stats_socket import StatsSocket
@@ -376,6 +376,13 @@ class Balancer(object):
         except socket.error, e:
             if e.errno not in (errno.EPIPE, errno.ETIMEDOUT, errno.ECONNRESET):
                 logging.error(traceback.format_exc())
+        except NoHealthyBackends, e:
+            logging.error("No healthy bakckends available!")
+            try:
+                sock.sendall("HTTP/1.0 597 No Healthy Backends\r\n\r\nNo healthy bakckends available.")
+            except socket.error, e:
+                if e.errno != errno.EPIPE:
+                    raise
         except:
             logging.error(traceback.format_exc())
             try:


### PR DESCRIPTION
Currently when there are no backend available in pool Mantrid is
throwing general exception. We want to handle it in more civilized
way so nginx can catch a problem and fallback to other grid
clusters.

This fix is needed for az-separation, as when setting up new cluster
it will not have any backends set in mantrid. As workers connect
only to nginx->mantrid correlated to their grid, we don't want them
to throw errors and bother anyone, so let's just let nginx to
connect to other, healthy grid cluster.