### PR TITLE
Log X-Request-Id if present

### DIFF
--- a/mantrid/actions.py
+++ b/mantrid/actions.py
@@ -174,7 +174,7 @@ class Proxy(Action):
         request_id = headers.get("X-Request-Id", "-")
         for attempt in range(self.attempts):
             if attempt > 0:
-                logging.warn("Retrying connection for host %s, request-id: %s", self.host, request_id)
+                logging.warn("[%s] Retrying connection for host %s", request_id, self.host)
 
             backend = self.select_backend()
             try:
@@ -187,12 +187,12 @@ class Proxy(Action):
                 backend.add_connection()
                 break
             except socket.error:
-                logging.exception("Proxy socket error on connect() to %s of %s, request-id: %s", backend, self.host, request_id)
+                logging.exception("[%s] Proxy socket error on connect() to %s of %s", request_id, backend, self.host)
                 self.blacklist(backend)
                 eventlet.sleep(self.delay)
                 continue
             except:
-                logging.warn("Proxy timeout on connect() to %s of %s, request-id: %s", backend, self.host, request_id)
+                logging.warn("[%s] Proxy timeout on connect() to %s of %s", request_id, backend, self.host)
                 self.blacklist(backend)
                 eventlet.sleep(self.delay)
                 continue

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -378,17 +378,17 @@ class Balancer(object):
                 stats_dict['bytes_received'] = stats_dict.get('bytes_received', 0) + sock.bytes_received
         except socket.error, e:
             if e.errno not in (errno.EPIPE, errno.ETIMEDOUT, errno.ECONNRESET):
-                logging.error("Loadbalancer socket error, error: %s, request-id: %s", request_id, e)
+                logging.error("[%s] Loadbalancer socket error, error: %s", request_id, e)
                 logging.error(traceback.format_exc())
         except NoHealthyBackends, e:
-            logging.error("No healthy bakckends available for host '%s', request-id: %s", host, request_id)
+            logging.error("[%s] No healthy bakckends available for host '%s'", request_id, host)
             try:
                 sock.sendall("HTTP/1.0 597 No Healthy Backends\r\n\r\nNo healthy bakckends available.")
             except socket.error, e:
                 if e.errno != errno.EPIPE:
                     raise
         except Exception, e:
-            logging.error("Internal Server Error, request id: %s, error: %s", request_id, e)
+            logging.error("[%s] Internal Server Error, error: %s", request_id, e)
             logging.error(traceback.format_exc())
             try:
                 sock.sendall("HTTP/1.0 500 Internal Server Error\r\n\r\nThere has been an internal error in the load balancer.")


### PR DESCRIPTION
API Proxy adds X-Request-Id header. Let's log it to improve visibility across backend requests.