### PR TITLE
Normalize mantrid logs

### DIFF
--- a/mantrid/actions.py
+++ b/mantrid/actions.py
@@ -174,7 +174,7 @@ class Proxy(Action):
         request_id = headers.get("X-Request-Id", "-")
         for attempt in range(self.attempts):
             if attempt > 0:
-                logging.warn("Retrying connection for host %s\" - \"%s", self.host, request_id)
+                logging.warn("[%s] Retrying connection for host %s", request_id, self.host)
 
             backend = self.select_backend()
             try:
@@ -187,12 +187,12 @@ class Proxy(Action):
                 backend.add_connection()
                 break
             except socket.error:
-                logging.error("Proxy socket error on connect() to %s of %s\" - \"%s", backend, self.host, request_id)
+                logging.error("[%s] Proxy socket error on connect() to %s of %s", request_id, backend, self.host)
                 self.blacklist(backend)
                 eventlet.sleep(self.delay)
                 continue
             except:
-                logging.warn("Proxy timeout on connect() to %s of %s\" - \"%s", backend, self.host, request_id)
+                logging.warn("[%s] Proxy timeout on connect() to %s of %s", request_id, backend, self.host)
                 self.blacklist(backend)
                 eventlet.sleep(self.delay)
                 continue

--- a/mantrid/actions.py
+++ b/mantrid/actions.py
@@ -174,7 +174,7 @@ class Proxy(Action):
         request_id = headers.get("X-Request-Id", "-")
         for attempt in range(self.attempts):
             if attempt > 0:
-                logging.warn("[%s] Retrying connection for host %s", request_id, self.host)
+                logging.warn("Retrying connection for host %s\" - \"%s", self.host, request_id)
 
             backend = self.select_backend()
             try:
@@ -187,12 +187,12 @@ class Proxy(Action):
                 backend.add_connection()
                 break
             except socket.error:
-                logging.error("[%s] Proxy socket error on connect() to %s of %s", request_id, backend, self.host)
+                logging.error("Proxy socket error on connect() to %s of %s\" - \"%s", backend, self.host, request_id)
                 self.blacklist(backend)
                 eventlet.sleep(self.delay)
                 continue
             except:
-                logging.warn("[%s] Proxy timeout on connect() to %s of %s", request_id, backend, self.host)
+                logging.warn("Proxy timeout on connect() to %s of %s\" - \"%s", backend, self.host, request_id)
                 self.blacklist(backend)
                 eventlet.sleep(self.delay)
                 continue
@@ -213,7 +213,7 @@ class Proxy(Action):
 
     def blacklist(self, backend):
         if self.healthcheck and not backend.blacklisted:
-            logging.warn("Blacklisting backend %s", backend)
+            logging.warn("Blacklisting backend %s of %s", backend, self.host)
             backend.blacklisted = True
 
 

--- a/mantrid/actions.py
+++ b/mantrid/actions.py
@@ -187,7 +187,7 @@ class Proxy(Action):
                 backend.add_connection()
                 break
             except socket.error:
-                logging.exception("[%s] Proxy socket error on connect() to %s of %s", request_id, backend, self.host)
+                logging.error("[%s] Proxy socket error on connect() to %s of %s", request_id, backend, self.host)
                 self.blacklist(backend)
                 eventlet.sleep(self.delay)
                 continue

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -1,7 +1,6 @@
 import eventlet
 import errno
 import logging
-import traceback
 import mimetools
 import resource
 import os
@@ -218,8 +217,8 @@ class Balancer(object):
             pool.wait()
         except (KeyboardInterrupt, StopIteration, SystemExit):
             pass
-        except:
-            logging.error(traceback.format_exc())
+        except Exception, e:
+            logging.error("Unhandled Exception %s" % e)
         # We're done
         self.running = False
         logging.info("Exiting")
@@ -379,7 +378,6 @@ class Balancer(object):
         except socket.error, e:
             if e.errno not in (errno.EPIPE, errno.ETIMEDOUT, errno.ECONNRESET):
                 logging.error("[%s] Loadbalancer socket error, error: %s", request_id, e)
-                logging.error(traceback.format_exc())
         except NoHealthyBackends, e:
             logging.error("[%s] No healthy bakckends available for host '%s'", request_id, host)
             try:
@@ -389,7 +387,6 @@ class Balancer(object):
                     raise
         except Exception, e:
             logging.error("[%s] Internal Server Error, error: %s", request_id, e)
-            logging.error(traceback.format_exc())
             try:
                 sock.sendall("HTTP/1.0 500 Internal Server Error\r\n\r\nThere has been an internal error in the load balancer.")
             except socket.error, e:
@@ -399,8 +396,8 @@ class Balancer(object):
             try:
                 sock.close()
                 rfile.close()
-            except:
-                logging.error(traceback.format_exc())
+            except Exception, e:
+                logging.error("Unhandled Exception %s" % e)
 
     def _set_hosts(self, hosts):
         self.__dict__['hosts'] = ManagedHostDict(hosts)

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -88,7 +88,7 @@ class Balancer(object):
         # Output to stderr, always
         sh = logging.StreamHandler()
         sh.setFormatter(logging.Formatter(
-            fmt = "\"%(asctime)s\" - \"%(levelname)8s\" - \"%(message)s\"",
+            fmt = "\"%(asctime)s\" - \"%(levelname)s\" - \"%(message)s\"",
             datefmt="%Y-%m-%d %H:%M:%S",
         ))
         sh.setLevel(logging.DEBUG)

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -88,7 +88,7 @@ class Balancer(object):
         # Output to stderr, always
         sh = logging.StreamHandler()
         sh.setFormatter(logging.Formatter(
-            fmt = "%(asctime)s - %(levelname)8s: %(message)s",
+            fmt = "\"%(asctime)s\" - \"%(levelname)8s\" - \"%(message)s\"",
             datefmt="%Y-%m-%d %H:%M:%S",
         ))
         sh.setLevel(logging.DEBUG)
@@ -377,16 +377,16 @@ class Balancer(object):
                 stats_dict['bytes_received'] = stats_dict.get('bytes_received', 0) + sock.bytes_received
         except socket.error, e:
             if e.errno not in (errno.EPIPE, errno.ETIMEDOUT, errno.ECONNRESET):
-                logging.error("[%s] Loadbalancer socket error, error: %s", request_id, e)
+                logging.error("Loadbalancer socket error, error: %s\" - \"%s", e, request_id)
         except NoHealthyBackends, e:
-            logging.error("[%s] No healthy bakckends available for host '%s'", request_id, host)
+            logging.error("No healthy backends available for host '%s'\" - \"%s", host, request_id)
             try:
-                sock.sendall("HTTP/1.0 597 No Healthy Backends\r\n\r\nNo healthy bakckends available.")
+                sock.sendall("HTTP/1.0 597 No Healthy Backends\r\n\r\nNo healthy backends available.")
             except socket.error, e:
                 if e.errno != errno.EPIPE:
                     raise
         except Exception, e:
-            logging.error("[%s] Internal Server Error, error: %s", request_id, e)
+            logging.error("Internal Server Error, error: %s\" - \"%s", e, request_id)
             try:
                 sock.sendall("HTTP/1.0 500 Internal Server Error\r\n\r\nThere has been an internal error in the load balancer.")
             except socket.error, e:

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -88,7 +88,7 @@ class Balancer(object):
         # Output to stderr, always
         sh = logging.StreamHandler()
         sh.setFormatter(logging.Formatter(
-            fmt = "\"%(asctime)s\" - \"%(levelname)s\" - \"%(message)s\"",
+            fmt = "%(asctime)s - %(levelname)s - %(message)s";,
             datefmt="%Y-%m-%d %H:%M:%S",
         ))
         sh.setLevel(logging.DEBUG)
@@ -377,16 +377,16 @@ class Balancer(object):
                 stats_dict['bytes_received'] = stats_dict.get('bytes_received', 0) + sock.bytes_received
         except socket.error, e:
             if e.errno not in (errno.EPIPE, errno.ETIMEDOUT, errno.ECONNRESET):
-                logging.error("Loadbalancer socket error, error: %s\" - \"%s", e, request_id)
+                logging.error("[%s] Loadbalancer socket error, error: %s", request_id, e)
         except NoHealthyBackends, e:
-            logging.error("No healthy backends available for host '%s'\" - \"%s", host, request_id)
+            logging.error("[%s] No healthy backends available for host '%s'", request_id, host)
             try:
                 sock.sendall("HTTP/1.0 597 No Healthy Backends\r\n\r\nNo healthy backends available.")
             except socket.error, e:
                 if e.errno != errno.EPIPE:
                     raise
         except Exception, e:
-            logging.error("Internal Server Error, error: %s\" - \"%s", e, request_id)
+            logging.error("[%s] Internal Server Error, error: %s", request_id, e)
             try:
                 sock.sendall("HTTP/1.0 500 Internal Server Error\r\n\r\nThere has been an internal error in the load balancer.")
             except socket.error, e:

--- a/mantrid/loadbalancer.py
+++ b/mantrid/loadbalancer.py
@@ -88,7 +88,7 @@ class Balancer(object):
         # Output to stderr, always
         sh = logging.StreamHandler()
         sh.setFormatter(logging.Formatter(
-            fmt = "%(asctime)s - %(levelname)s - %(message)s";,
+            fmt = "%(asctime)s - %(levelname)s - %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         ))
         sh.setLevel(logging.DEBUG)

--- a/mantrid/socketmeld.py
+++ b/mantrid/socketmeld.py
@@ -67,11 +67,11 @@ class SocketMelder(object):
         try:
             self.server.close()
         except:
-            logging.exception("Exception caught closing server socket, backend %s of %s", self.backend, self.host)
+            logging.error("Exception caught closing server socket, backend %s of %s", self.backend, self.host)
 
         try:
             self.client.close()
         except:
-            logging.exception("Exception caught closing client socket, backend: %s of %s", self.backend, self.host)
+            logging.error("Exception caught closing client socket, backend: %s of %s", self.backend, self.host)
 
         return self.data_handled


### PR DESCRIPTION
1. Don't log stack traces
2. Severity string (INFO, ERROR, etc) is not of fixed size any more

Sample 
```
 2015-03-10 15:19:59 - INFO - Using configuration file /etc/mantrid/mantrid.conf
 2015-03-10 15:20:00 - INFO - Dropped to GID 2020
 2015-03-10 15:20:00 - INFO - Dropped to UID 2020
 2015-03-10 15:20:00 - INFO - Listening for requests on ('::', 9999)
 2015-03-10 15:20:00 - INFO - Listening for requests on ('::', 8080)
 2015-03-10 15:20:00 - INFO - Listening for management on ('::', 8042)
 2015-03-10 15:20:16 - ERROR - [-] Proxy socket error on connect() to Backend((127.0.0.1, 8889)) of test42-elb.fs.production
 2015-03-10 15:20:16 - WARNING - Blacklisting backend Backend((127.0.0.1, 8889)) of test42-elb.fs.production
 2015-03-10 15:20:17 - WARNING - [-] Retrying connection for host test42-elb.fs.production
 2015-03-10 15:20:17 - ERROR - [-] No healthy backends available for host 'test42-elb.fs.production'
 2015-03-10 15:20:28 - ERROR - [-] No healthy backends available for host 'test42-elb.fs.production'
 2015-03-10 15:21:22 - ERROR - [request_id] No healthy backends available for host 'test42-elb.fs.production'
 2015-03-10 15:21:45 - WARNING - Stopping health-checking of Backend((127.0.0.1, 8889)): available
```