### PR TITLE
Fix bug with connection timeouts.

### DIFF
--- a/mantrid/actions.py
+++ b/mantrid/actions.py
@@ -18,7 +18,11 @@ from mantrid.socketmeld import SocketMelder
 
 class NoHealthyBackends(Exception):
     "Poll of usable backends is empty"
-    pass
+
+
+class AllConnectionAttemptsFailed(Exception):
+    "Failed to connect despite retries"
+
 
 class Action(object):
     "Base action. Doesn't do anything."
@@ -196,6 +200,9 @@ class Proxy(Action):
                 self.blacklist(backend)
                 eventlet.sleep(self.delay)
                 continue
+        else:
+            raise AllConnectionAttemptsFailed()
+
 
         # Function to help track data usage
         def send_onwards(data):


### PR DESCRIPTION
It fails to abort when all connection attempts time out and there are more
backends than configured connection attempts.

Now a proper exception will be thrown explicitly.